### PR TITLE
Clean-up for Auto-Job Advancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 AzureMS/out/*
 AzureMS/.idea/
 AzureMS/build/*
+AzureMS/AzureSrc.iml
+AzureMS/property/Logs/*
+.idea/

--- a/AzureMS/AzureSrc.iml
+++ b/AzureMS/AzureSrc.iml
@@ -5,7 +5,6 @@
     <output-test url="file://$MODULE_DIR$/build/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
-      <excludeFolder url="file://$MODULE_DIR$/target" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/AzureMS/pom.xml
+++ b/AzureMS/pom.xml
@@ -9,11 +9,13 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
+        <project.build.sourceEncoding>x-windows-949</project.build.sourceEncoding>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
     </properties>
 
     <build>
+        <sourceDirectory>src</sourceDirectory>
         <directory>${project.basedir}/build</directory>
         <outputDirectory>${project.build.directory}/classes</outputDirectory>
 
@@ -55,6 +57,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
+                    <encoding>x-windows-949</encoding>
                     <source/>
                     <target/>
                 </configuration>

--- a/AzureMS/src/client/Character/MapleCharacter.java
+++ b/AzureMS/src/client/Character/MapleCharacter.java
@@ -91,6 +91,7 @@ import client.Skills.SkillEffectEntry;
 import client.Skills.StealSkillEntry;
 import constants.GameConstants;
 import constants.ServerConstants;
+import constants.JobConstants;
 import constants.Data.QuickMoveEntry;
 import connections.Database.MYSQL;
 import connections.Database.MYSQLException;
@@ -9372,525 +9373,113 @@ public class MapleCharacter extends AnimatedHinaMapObjectExtend implements Inven
         return num_;
     }
 
+    private boolean advancementWrapper(String jobID) {
+        try {
+            // Send job advancement message; concat generic prefix with job name
+            getClient().send(UIPacket.showInfo(JobConstants.advancePrefix + JobConstants.JOB_NAME.get(Short.valueOf(jobID))));
+            changeJob(Short.parseShort(jobID));  // Change job
+
+            // Max particular skills
+            // No idea why this is here - this in Azure from day 1 of Soul releasing the source
+            if (jobID == String.valueOf(JobConstants.DAWN_WARRIOR_IV)) {
+                changeSkillLevel(11121000, (byte) 30, (byte) 30);
+            }
+            else if (jobID == String.valueOf(JobConstants.BLAZE_WIZARD_IV)) {
+                changeSkillLevel(12121000, (byte) 30, (byte) 30);
+            }
+            else if (jobID == String.valueOf(JobConstants.WIND_ARCHER_IV)) {
+                changeSkillLevel(13121000, (byte) 30, (byte) 30);
+            }
+            else if (jobID == String.valueOf(JobConstants.NIGHT_WALKER_IV)) {
+                changeSkillLevel(14121000, (byte) 30, (byte) 30);
+            }
+            else if (jobID == String.valueOf(JobConstants.THUNDER_BREAKER_IV)) {
+                changeSkillLevel(15121000, (byte) 30, (byte) 30);
+            }
+            return true;
+        }
+        catch(Exception e) {
+            String errorMessage = String.format("Error setting job! Job ID: %s", jobID);
+            System.err.println(errorMessage);  // Log to console
+            dropMessage(5, errorMessage);  // Inform the user
+            return false;
+        }
+    }
+
     public boolean AutoJob() {
-        if (getKeyValue("AutoJob") != null) {
-            if (level == 20) {
-                switch (getKeyValue("AutoJob")) {
-                    case "430":
-                        getClient().send(UIPacket.showInfo("[Rememberer of darkness] I changed to semi-dudor."));
-                        changeJob(430);
-                        setKeyValue("AutoJob", "430");
-                        return true;
-                }
+        // Experimental; please roll back if this breaks auto-job advancement
+        // advancementWrapper(String jobID) handles the job advancement and
+        if (getKeyValue("AutoJob") != null && !GameConstants.isZero(getJob())) {  // Rebirth breaks Zero's lv100 start point
+            if (level == 20 &&
+                    getKeyValue("AutoJob").equals(String.valueOf(JobConstants.BLADE_RECRUIT))) {
+                // Only DB Job advances at lv 20
+                advancementWrapper(String.valueOf(JobConstants.BLADE_RECRUIT));
+                setKeyValue("AutoJob", String.valueOf(JobConstants.BLADE_RECRUIT));
+                return true;
             } else if (level == 30) {
-                switch (getKeyValue("AutoJob")) {
-                    case "110":
-                        getClient().send(UIPacket.showInfo("[Two-handed swordsman] Changed to Fighter."));
-                        changeJob(110);
-                        return true;
-                    case "120":
-                        getClient().send(UIPacket.showInfo("[One-handed Sword Knight] Changed to Page."));
-                        changeJob(120);
-                        return true;
-                    case "130":
-                        getClient().send(UIPacket.showInfo("[Knight] Changed to Spearman."));
-                        changeJob(130);
-                        return true;
-                    case "210":
-                        getClient().send(UIPacket.showInfo("[Fire*Poison] Changed to Wizard."));
-                        changeJob(210);
-                        return true;
-                    case "220":
-                        getClient().send(UIPacket.showInfo("[Ice*lightning] Changed to Wizard."));
-                        changeJob(220);
-                        return true;
-                    case "230":
-                        getClient().send(UIPacket.showInfo("[Heal*Buff] Changed to Cleric."));
-                        changeJob(230);
-                        return true;
-                    case "310":
-                        getClient().send(UIPacket.showInfo("[Shooter] I changed to Hunter."));
-                        changeJob(310);
-                        return true;
-                    case "320":
-                        getClient().send(UIPacket.showInfo("[Next shooter] Changed to shooter."));
-                        changeJob(320);
-                        return true;
-                    case "330":
-                        getClient().send(UIPacket.showInfo("[Action] I changed to Ancient Archer."));
-                        changeJob(330);
-                        return true;
-                    case "410":
-                        getClient().send(UIPacket.showInfo("[Recognition assassination Beginner] Changed to Assassin."));
-                        changeJob(410);
-                        return true;
-                    case "420":
-                        getClient().send(UIPacket.showInfo("[Sword assassination initiation period] shifted to Seef."));
-                        changeJob(420);
-                        return true;
-                    case "510":
-                        getClient().send(UIPacket.showInfo("[Knuckle Beginner] Changed to Infinite."));
-                        changeJob(510);
-                        return true;
-                    case "520":
-                        getClient().send(UIPacket.showInfo("[Gun Beginner] Changed to Gunslinger."));
-                        changeJob(520);
-                        return true;
-                    case "430":
-                        getClient().send(UIPacket.showInfo("[The Dark Past] Changed to Durer."));
-                        changeJob(431);
-                        return true;
-                    case "530":
-                        getClient().send(UIPacket.showInfo("[Introductory Cannon] Changed to Cannon Shooter."));
-                        changeJob(530);
-                        return true;
-                    case "1110":
-                        getClient().send(UIPacket.showInfo("[Introductory Cygnus] Changed to Light Knight."));
-                        changeJob(1110);
-                        return true;
-                    case "1210":
-                        getClient().send(UIPacket.showInfo("[Introductory Cygnus] Changed to Fire Knight."));
-                        changeJob(1210);
-                        return true;
-                    case "1310":
-                        getClient().send(UIPacket.showInfo("[Introductory Cygnus] Changed to Knight of the Wind."));
-                        changeJob(1310);
-                        return true;
-                    case "1410":
-                        getClient().send(UIPacket.showInfo("[Initiator for Cygnus] Changed to Dark Knight."));
-                        changeJob(1410);
-                        return true;
-                    case "1510":
-                        getClient().send(UIPacket.showInfo("[Introductory Cygnus] Changed to Lightning Knight."));
-                        changeJob(1510);
-                        return true;
-                    case "2110":
-                        getClient().send(UIPacket.showInfo("[Heroic Instinct] Changed to Aran."));
-                        changeJob(2110);
-                        return true;
-                    case "2210":
-                        getClient().send(UIPacket.showInfo("[Second Step] Changed to Evan."));
-                        changeJob(2211);
-                        return true;
-                    case "2310":
-                        getClient().send(UIPacket.showInfo("[Heroic Instinct] Changed to Mercedes."));
-                        changeJob(2310);
-                        return true;
-                    case "2410":
-                        getClient().send(UIPacket.showInfo("[Heroic Instinct] Changed to Phantom."));
-                        changeJob(2410);
-                        return true;
-                    case "2510":
-                        getClient().send(UIPacket.showInfo("[Heroic Instinct] Changed to Eunwol."));
-                        changeJob(2510);
-                        return true;
-                    case "2710":
-                        getClient().send(UIPacket.showInfo("Hero's Instinct] Changed to Luminous."));
-                        changeJob(2710);
-                        return true;
-                    case "3110":
-                        getClient().send(UIPacket.showInfo("[Introduction to Resistance] Changed to Daemon Slayer."));
-                        changeJob(3110);
-                        return true;
-                    case "3120":
-                        getClient().send(UIPacket.showInfo("[Introduction to Resistance] Changed to Daemon Avenger."));
-                        changeJob(3120);
-                        return true;
-                    case "3210":
-                        getClient().send(UIPacket.showInfo("[Introduction to Resistance] Changed to Battle Mage."));
-                        changeJob(3210);
-                        return true;
-                    case "3310":
-                        getClient().send(UIPacket.showInfo("[Introduction to Resistance] Changed to Wild Hunter."));
-                        changeJob(3310);
-                        return true;
-                    case "3510":
-                        getClient().send(UIPacket.showInfo("[Introduction to Resistance] Changed to Mechanic."));
-                        changeJob(3510);
-                        return true;
-                    case "3610":
-                        getClient().send(UIPacket.showInfo("[Introduction to Resistance] Moved to Xenon."));
-                        changeJob(3610);
-                        return true;
-                    case "3710":
-                        getClient().send(UIPacket.showInfo("[Introduction to Resistance] He changed to Blaster."));
-                        changeJob(3710);
-                        return true;
-                    case "5110":
-                        getClient().send(UIPacket.showInfo("[Director of Cygnus] Changed to Light Knight."));
-                        changeJob(5110);
-                        return true;
-                    case "6110":
-                        getClient().send(UIPacket.showInfo("[Nova trainee] Changed to Kaiser."));
-                        changeJob(6110);
-                        return true;
-                    case "6510":
-                        getClient().send(UIPacket.showInfo("[Nova trainee] Changed to Angelic Buster."));
-                        changeJob(6510);
-                        return true;
-                    case "14200":
-                        getClient().send(UIPacket.showInfo("[Enlightenment of Super Power] Changed to Kinesis."));
-                        changeJob(14210);
-                        return true;
-                    case "6400":
-                        getClient().send(UIPacket.showInfo("[Enlightenment of Weapon] Changed to Cadena."));
-                        changeJob(6410);
-                        return true;
-                    case "15210":
-                        getClient().send(UIPacket.showInfo("[Magic Enlightenment] Changed to Illium."));
-                        changeJob(15210);
-                        return true;
-                    case "15510":
-                        getClient().send(UIPacket.showInfo("[Copper of Specter] Changed to Ark."));
-                        changeJob(15510);
-                        return true;
-                    default:
-                        return true;
+                if (!getKeyValue("AutoJob").equals(String.valueOf(JobConstants.BLADE_RECRUIT))) {
+                    // All non-Zero classes advance at lv 30
+                    // Evan and DB have odd advancement levels/job IDs
+                    if (getKeyValue("AutoJob").equals(String.valueOf(JobConstants.EVAN_I))) {
+                        return advancementWrapper(String.valueOf(JobConstants.EVAN_III));
+                    }
+                    else {
+                        // Send job advancement message; concat generic prefix with job name
+                        return advancementWrapper(getKeyValue("AutoJob"));
+                    }
                 }
-            } else if (level == 45) {
-                switch (getKeyValue("AutoJob")) {
-                    case "430":
-                        getClient().send(UIPacket.showInfo("Dark Identity Changed to Dualmaster."));
-                        changeJob(432);
-                        return true;
-                    default:
-                        return true;
+                else {
+                    return advancementWrapper(String.valueOf(JobConstants.BLADE_ACOLYTE));
                 }
+            } else if (level == 45 &&
+                    getKeyValue("AutoJob").equals(String.valueOf(JobConstants.BLADE_RECRUIT))) {
+                // Only DB Job advances at lv 45
+                return advancementWrapper(String.valueOf(JobConstants.BLADE_SPECIALIST));
             } else if (level == 60) {
-                switch (getKeyValue("AutoJob")) {
-                    case "110":
-                        getClient().send(UIPacket.showInfo("[Soul Fencing Knight] Changed to Crusader."));
-                        changeJob(111);
-                        return true;
-                    case "120":
-                        getClient().send(UIPacket.showInfo("[Professional Sword of Knight] Changed to Knight."));
-                        changeJob(121);
-                        return true;
-                    case "130":
-                        getClient().send(UIPacket.showInfo("[Dragon Sword Knight] was a dragon knight."));
-                        changeJob(131);
-                        return true;
-                    case "210":
-                        getClient().send(UIPacket.showInfo("[Fire*Poison] Changed to Meiji."));
-                        changeJob(211);
-                        return true;
-                    case "220":
-                        getClient().send(UIPacket.showInfo("[Ice*Lightning] Changed to Meiji."));
-                        changeJob(221);
-                        return true;
-                    case "230":
-                        getClient().send(UIPacket.showInfo("[Heal*Buff] I'm a former priest."));
-                        changeJob(231);
-                        return true;
-                    case "310":
-                        getClient().send(UIPacket.showInfo("[Series shooter] Changed to Ranger."));
-                        changeJob(311);
-                        return true;
-                    case "320":
-                        getClient().send(UIPacket.showInfo("[Brown-backed shooter] Changed to sniper."));
-                        changeJob(321);
-                        return true;
-                    case "330":
-                        getClient().send(UIPacket.showInfo("[Master of Ancients] Changed to Chaser."));
-                        changeJob(331);
-                        return true;
-                    case "410":
-                        getClient().send(UIPacket.showInfo("[Assassination Specialist] I changed to Hermit."));
-                        changeJob(411);
-                        return true;
-                    case "420":
-                        getClient().send(UIPacket.showInfo("[The Darkman] Changed to Sheep Master."));
-                        changeJob(421);
-                        return true;
-                    case "510":
-                        getClient().send(UIPacket.showInfo("[Dragon Knuckle Fighter] Changed to Buccaneer."));
-                        changeJob(511);
-                        return true;
-                    case "520":
-                        getClient().send(UIPacket.showInfo("[Gun Mastery] I changed to Valkyrie."));
-                        changeJob(521);
-                        return true;
-                    case "430":
-                        getClient().send(UIPacket.showInfo("[Knowing the Darkness] She changed to Slasher."));
-                        changeJob(433);
-                        return true;
-                    case "530":
-                        getClient().send(UIPacket.showInfo("[Canon Mastery] Changed to Cannon Shooter."));
-                        changeJob(531);
-                        return true;
-                    case "2110":
-                        getClient().send(UIPacket.showInfo("[Hero's Enlightenment] Changed to Aran."));
-                        changeJob(2111);
-                        return true;
-                    case "2210":
-                        getClient().send(UIPacket.showInfo("[Evolutionary Dragon] Changed to Evan."));
-                        changeJob(2214);
-                        return true;
-                    case "2310":
-                        getClient().send(UIPacket.showInfo("[Hero's Enlightenment] Changed to Mercedes."));
-                        changeJob(2311);
-                        return true;
-                    case "2410":
-                        getClient().send(UIPacket.showInfo("[Hero's Enlightenment] Changed to Phantom."));
-                        changeJob(2411);
-                        return true;
-                    case "2510":
-                        getClient().send(UIPacket.showInfo("[Hero's Enlightenment] Changed to Eunwol."));
-                        changeJob(2511);
-                        return true;
-                    case "2710":
-                        getClient().send(UIPacket.showInfo("[Hero's Enlightenment] Changed to Luminous."));
-                        changeJob(2711);
-                        return true;
-                    case "3110":
-                        getClient().send(UIPacket.showInfo("[Resistence Agent] Changed to Daemon Slayer."));
-                        changeJob(3111);
-                        return true;
-                    case "3120":
-                        getClient().send(UIPacket.showInfo("[Resistence Agent] Changed to Daemon Avenger."));
-                        changeJob(3121);
-                        return true;
-                    case "3210":
-                        getClient().send(UIPacket.showInfo("[Resistence Agent] Changed to Battle Mage."));
-                        changeJob(3211);
-                        return true;
-                    case "3310":
-                        getClient().send(UIPacket.showInfo("[Resistence Agent] Changed to Wild Hunter."));
-                        changeJob(3311);
-                        return true;
-                    case "3510":
-                        getClient().send(UIPacket.showInfo("[Resistence Agent] Changed to Mechanic."));
-                        changeJob(3511);
-                        return true;
-                    case "3610":
-                        getClient().send(UIPacket.showInfo("[Resistence Agent] Changed to Xenon."));
-                        changeJob(3611);
-                        return true;
-                    case "3710":
-                        getClient().send(UIPacket.showInfo("[Resistence Agent] Changed to Blaster."));
-                        changeJob(3711);
-                        return true;
-                    case "5110":
-                        getClient().send(UIPacket.showInfo("[Director of Cygnus] Changed to Light Knight."));
-                        changeJob(5111);
-                        return true;
-                    case "6110":
-                        getClient().send(UIPacket.showInfo("[Guardian of Nova] Changed to Kaiser."));
-                        changeJob(6111);
-                        return true;
-                    case "6510":
-                        getClient().send(UIPacket.showInfo("[Guardian of Nova] Changed to Angelic Buster."));
-                        changeJob(6511);
-                        return true;
-                    case "1110":
-                        getClient().send(UIPacket.showInfo("[Cygnus Official Article] Changed to Soul Master."));
-                        changeJob(1111);
-                        return true;
-                    case "1210":
-                        getClient().send(UIPacket.showInfo("[Cygnus Official Article] Changed to Flame Wizard."));
-                        changeJob(1211);
-                        return true;
-                    case "1310":
-                        getClient().send(UIPacket.showInfo("[Cygnus Official Article] Changed to Windbreaker."));
-                        changeJob(1311);
-                        return true;
-                    case "1410":
-                        getClient().send(UIPacket.showInfo("[Cygnus Official Article] Changed to Night Walker."));
-                        changeJob(1411);
-                        return true;
-                    case "1510":
-                        getClient().send(UIPacket.showInfo("[Cygnus Official Article] Striker Changed."));
-                        changeJob(1511);
-                        return true;
-                    case "14200":
-                        getClient().send(UIPacket.showInfo("[Enlightenment of Super Power] I changed to Kinesis."));
-                        changeJob(14211);
-                        return true;
-                    case "6400":
-                        getClient().send(UIPacket.showInfo("[Weapon master] Changed to Cadena."));
-                        changeJob(6411);
-                        return true;
-                    case "15210":
-                        getClient().send(UIPacket.showInfo("[Magic Master] Changed to Illium."));
-                        changeJob(15211);
-                        return true;
-                    case "15510":
-                        getClient().send(UIPacket.showInfo("[The Spectator] Ex-Arc."));
-                        changeJob(15511);
-                        return true;
+                if (!getKeyValue("AutoJob").equals(String.valueOf(JobConstants.BLADE_RECRUIT))) {
+                    // All non-Zero classes advance at lv 60
+                    // Evan and DB have odd advancement levels/job IDs
+                    // Evan:
+                    if (getKeyValue("AutoJob").equals(String.valueOf(JobConstants.EVAN_I))) {
+                        return advancementWrapper(String.valueOf(JobConstants.EVAN_VI));
+                    }
+                    else {
+                        // non-Evan, non-DB classes
+                        short targetID = Short.parseShort(getKeyValue("AutoJob"));
+                        targetID += 1;  // raise to target job ID
+                        // Send job advancement message; concat generic prefix with job name
+                        return advancementWrapper(String.valueOf(targetID));
+                    }
+                }
+                else {
+                    //DB:
+                    return advancementWrapper(String.valueOf(JobConstants.BLADE_LORD));
                 }
             } else if (level == 100) {
-                switch (getKeyValue("AutoJob")) {
-                    case "110":
-                        getClient().send(UIPacket.showInfo("[Master of Chain Swordsman] Changed to Hero."));
-                        changeJob(112);
-                        return true;
-                    case "120":
-                        getClient().send(UIPacket.showInfo("[Master of Fantasy Swordsman] Changed to Paladin."));
-                        changeJob(122);
-                        return true;
-                    case "130":
-                        getClient().send(UIPacket.showInfo("[Master of Dark Dragon Spear] Changed to Dark Knight."));
-                        changeJob(132);
-                        return true;
-                    case "210":
-                        getClient().send(UIPacket.showInfo("[Fire*Poison Master] Changed to Archmage."));
-                        changeJob(212);
-                        return true;
-                    case "220":
-                        getClient().send(UIPacket.showInfo("[Ice*Lightning Master] Changed to Archmage."));
-                        changeJob(222);
-                        return true;
-                    case "230":
-                        getClient().send(UIPacket.showInfo("[Heal*Buff Master] Changed to Bishop."));
-                        changeJob(232);
-                        return true;
-                    case "310":
-                        getClient().send(UIPacket.showInfo("[Arrow Speaker Master] Changed to Bow Master."));
-                        changeJob(312);
-                        return true;
-                    case "320":
-                        getClient().send(UIPacket.showInfo("[Master of Arrow Power] Changed to Shrine."));
-                        changeJob(322);
-                        return true;
-                    case "330":
-                        getClient().send(UIPacket.showInfo("[Ancient Master] Changed to Pathfinder."));
-                        changeJob(332);
-                        return true;
-                    case "410":
-                        getClient().send(UIPacket.showInfo("[Master of Chain Assassination] Changed to Knight Road."));
-                        changeJob(412);
-                        return true;
-                    case "420":
-                        getClient().send(UIPacket.showInfo("Dark Assassination Master Changed to Shadow."));
-                        changeJob(422);
-                        return true;
-                    case "510":
-                        getClient().send(UIPacket.showInfo("[Knuckle Fighter of Spirits] Changed to Viper."));
-                        changeJob(512);
-                        return true;
-                    case "520":
-                        getClient().send(UIPacket.showInfo("[Battle Gun Mastery] Former Captain."));
-                        changeJob(522);
-                        return true;
-                    case "430":
-                        getClient().send(UIPacket.showInfo("[Adjuster of Darkness] Changed to Dual Blade."));
-                        changeJob(434);
-                        return true;
-                    case "530":
-                        getClient().send(UIPacket.showInfo("[Canon Mastery of Destruction] Changed to Cannon Shooter."));
-                        changeJob(532);
-                        return true;
-                    case "2110":
-                        getClient().send(UIPacket.showInfo("[Hero's Resurrection] Changed to Aran."));
-                        changeJob(2112);
-                        return true;
-                    case "2210":
-                        getClient().send(UIPacket.showInfo("[Legendary Dragon] Changed to Evan."));
-                        changeJob(2217);
-                        return true;
-                    case "2310":
-                        getClient().send(UIPacket.showInfo("[Hero's Resurrection]."));
-                        changeJob(2312);
-                        return true;
-                    case "2410":
-                        getClient().send(UIPacket.showInfo("[Hero's Resurrection] Changed to Phantom."));
-                        changeJob(2412);
-                        return true;
-                    case "2510":
-                        getClient().send(UIPacket.showInfo("[Hero's Resurrection] Changed to Eunwol."));
-                        changeJob(2512);
-                        return true;
-                    case "2710":
-                        getClient().send(UIPacket.showInfo("[Hero's Resurrection] Changed to Luminous."));
-                        changeJob(2712);
-                        return true;
-                    case "3110":
-                        getClient().send(UIPacket.showInfo("[Hero of Resistance] Changed to Daemon Slayer."));
-                        changeJob(3112);
-                        return true;
-                    case "3120":
-                        getClient().send(UIPacket.showInfo("[Resistence Hero] Changed to Daemon Avenger."));
-                        changeJob(3122);
-                        return true;
-                    case "3210":
-                        getClient().send(UIPacket.showInfo("[Hero of Resistance] Changed to Battle Mage."));
-                        changeJob(3212);
-                        return true;
-                    case "3310":
-                        getClient().send(UIPacket.showInfo("[Hero of Resistance] Changed to Wild Hunter."));
-                        changeJob(3312);
-                        return true;
-                    case "3510":
-                        getClient().send(UIPacket.showInfo("[Hero of Resistance] Moved to Mechanic."));
-                        changeJob(3512);
-                        return true;
-                    case "3610":
-                        getClient().send(UIPacket.showInfo("[Hero of Resistance] Moved to Xenon."));
-                        changeJob(3612);
-                        return true;
-                    case "3710":
-                        getClient().send(UIPacket.showInfo("[Heroes of Resistance] Changed to Blaster."));
-                        changeJob(3712);
-                        return true;
-                    case "5110":
-                        getClient().send(UIPacket.showInfo("[Director of Cygnus] Changed to Light Knight."));
-                        changeJob(5112);
-                        return true;
-                    case "6110":
-                        getClient().send(UIPacket.showInfo("[Dragon Knight] Changed to Kaiser."));
-                        changeJob(6112);
-                        return true;
-                    case "6510":
-                        getClient().send(UIPacket.showInfo("[Idol of Battlefield] Changed to Angelic Buster."));
-                        changeJob(6512);
-                        return true;
-                    case "1110":
-                        getClient().send(UIPacket.showInfo("[Cygnus Hero] Changed to Great Spirit of Light."));
-                        changeJob(1112);
-                        changeSkillLevel(11121000, (byte) 30, (byte) 30);
-                        return true;
-                    case "1210":
-                        getClient().send(UIPacket.showInfo("[Cygnus Hero] Changed to Great Spirit of Fire."));
-                        changeJob(1212);
-                        changeSkillLevel(12121000, (byte) 30, (byte) 30);
-                        return true;
-                    case "1310":
-                        getClient().send(UIPacket.showInfo("[Cygnus Hero] Changed to Great Spirit of the Wind."));
-                        changeJob(1312);
-                        changeSkillLevel(13121000, (byte) 30, (byte) 30);
-                        return true;
-                    case "1410":
-                        getClient().send(UIPacket.showInfo("[Cygnus Hero] Changed to Dark Spirit."));
-                        changeJob(1412);
-                        changeSkillLevel(14121000, (byte) 30, (byte) 30);
-                        return true;
-                    case "1510":
-                        getClient().send(UIPacket.showInfo("[Cygnus Heroes] Changed to Great Spirit of Lightning."));
-                        changeJob(1512);
-                        changeSkillLevel(15121000, (byte) 30, (byte) 30);
-                        return true;
-                    case "14200":
-                        getClient().send(UIPacket.showInfo("[Superhero] Changed to Kinesis."));
-                        changeJob(14212);
-                        return true;
-                    case "6400":
-                        getClient().send(UIPacket.showInfo("[Hero of Nova] Changed to Cadena."));
-                        changeJob(6412);
-                        return true;
-                    case "15210":
-                        getClient().send(UIPacket.showInfo("[Magic Transcendence] Changed to Illium."));
-                        changeJob(15212);
-                        return true;
-                    case "15510":
-                        getClient().send(UIPacket.showInfo("[King of Specter] Advance to Ark."));
-                        changeJob(15512);
-                        return true;
+                if (!getKeyValue("AutoJob").equals(String.valueOf(JobConstants.BLADE_RECRUIT))) {
+                    // All non-Zero classes advance at lv 60
+                    // Evan and DB have odd advancement levels/job IDs
+                    // Evan:
+                    if (getKeyValue("AutoJob").equals(String.valueOf(JobConstants.EVAN_I))) {
+                        // I don't know why it's Evan IX; this in Azure from day 1 of Soul releasing the source
+                        return advancementWrapper(String.valueOf(JobConstants.EVAN_IX));
+                    } else {
+                        // non-Evan, non-DB classes
+                        short targetID = Short.parseShort(getKeyValue("AutoJob"));
+                        targetID += 2;  // raise to target job ID
+                        // Send job advancement message; concat generic prefix with job name
+                        return advancementWrapper(String.valueOf(targetID));
+                    }
+                }
+                else {
+                    //DB:
+                    return advancementWrapper(String.valueOf(JobConstants.BLADE_MASTER));
                 }
             }
         }
         return false;
     }
+
 
     public int getDamageSkin() {
         final List<MapleQuestStatus> started = getStartedQuests();

--- a/AzureMS/src/client/MapleClient.java
+++ b/AzureMS/src/client/MapleClient.java
@@ -24,7 +24,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import javax.script.ScriptEngine;
 
-import com.sun.security.ntlm.Server;
+// import com.sun.security.ntlm.Server;
 import connections.Database.MYSQLException;
 import client.Character.MapleCharacter;
 import client.Character.MapleCharacterUtil;

--- a/AzureMS/src/connections/Packets/MainPacketCreator.java
+++ b/AzureMS/src/connections/Packets/MainPacketCreator.java
@@ -4122,6 +4122,15 @@ public class MainPacketCreator {
      * (빨간바탕에 검은색) 17 : (진보라색) 18 : (연한파란색바탕에 분홍색) 19 : (갈색바탕에 검은색) 20 : (갈색바탕에
      * 흰색) 21 : (노란색바탕에 검은색) 22 : (초록색바탕에 흰색) 23 : (초록색바탕에 갈색[W:-1]) 25 : (노란색)
      * 26 : (하늘색) 27 : (작은 글씨체)
+     *
+     * Translation: KOOKIIE
+     * <code>Colour Codes</code>:<br>
+     * 0 : Normal (White) 1 : Whispers (Green) 2 : Party (Pink) 3 : Buddy (Orange) 4 : Guild (Purple)
+     * 5 : (Pale Green) 6 : (Slightly Darker Pink) 7 : (Grey) 8 : (Yellow) 9 : (Light Yellow)
+     * 10 : (Blue) 11 : GM (Black on White) 12 : (Brown) 13 : (Blue on Pale Blue) 15 : (Black on Red)
+     * 17 : (Aubergine) 18 : (Pink on Light Blue) 19 : (Black on Brown) 20 : (White on Brown
+     * 21 : (Black on Yellow) 22 : (White on Green) 23 : (Brown on Green[W:-1]) 25 : (Yellow)
+     * 26 : (Sky Blue) 27 : (Fine Print)
      */
     public static byte[] getGMText(int type, String text) {
         WritingPacket packet = new WritingPacket();

--- a/AzureMS/src/constants/JobConstants.java
+++ b/AzureMS/src/constants/JobConstants.java
@@ -1,0 +1,389 @@
+package constants;
+
+import java.util.HashMap;
+import java.util.Map;
+import client.Character.MapleCharacter;
+
+public class JobConstants {
+    // real: @author Brandon / Not Brandon#4444
+    // git-blame: @author Desc / Akshay / Desc#0416
+    /*
+    // KOOKIIE's note:
+    - Ported over from ***REDACTED***
+    - Added new constants
+    - Changed roman numerals to normal
+    - Fixed typos
+    - Fixed copy-paste errors
+     */
+
+
+    // Beginner
+    public final static short BEGINNER = 0;
+
+    // Hero
+    public final static short WARRIOR = 100;
+    public final static short FIGHTER = 110;
+    public final static short CRUSADER = 111;
+    public final static short HERO = 112;
+
+    // Paladin
+    public final static short PAGE = 120;
+    public final static short WHITE_KNIGHT = 121;
+    public final static short PALADIN = 122;
+
+    // Dark Knight
+    public final static short SPEARMAN = 130;
+    public final static short DRAGON_KNIGHT = 131;
+    public final static short DARK_KNIGHT = 132;
+
+    // Magician (F/P)
+    public final static short MAGICIAN = 200;
+    public final static short FIRE_POISON_I = 210;
+    public final static short FIRE_POISON_II = 211;
+    public final static short FIRE_POISON_III = 212;
+
+    // Magician (I/L)
+    public final static short ICE_LIGHTNING_I = 220;
+    public final static short ICE_LIGHTNING_II = 221;
+    public final static short ICE_LIGHTNING_III = 222;
+
+    // Bishop
+    public final static short CLERIC = 230;
+    public final static short PRIEST = 231;
+    public final static short BISHOP = 232;
+
+    // Archer
+    public final static short ARCHER = 300;
+    public final static short HUNTER = 310;
+    public final static short RANGER = 311;
+    public final static short BOWMASTER = 312;
+
+    // DB
+    public final static short BLADE_RECRUIT = 430;
+    public final static short BLADE_ACOLYTE = 431;
+    public final static short BLADE_SPECIALIST = 432;
+    public final static short BLADE_LORD = 433;
+    public final static short BLADE_MASTER = 434;
+
+    // Dawn Warrior
+    public final static short DAWN_WARRIOR_I = 1100;
+    public final static short DAWN_WARRIOR_II = 1110;
+    public final static short DAWN_WARRIOR_III = 1111;
+    public final static short DAWN_WARRIOR_IV = 1112;
+
+    // Blaze Wizard
+    public final static short BLAZE_WIZARD_I = 1200;
+    public final static short BLAZE_WIZARD_II = 1210;
+    public final static short BLAZE_WIZARD_III = 1211;
+    public final static short BLAZE_WIZARD_IV = 1212;
+
+    // Wind Archer
+    public final static short WIND_ARCHER_I = 1300;
+    public final static short WIND_ARCHER_II = 1310;
+    public final static short WIND_ARCHER_III = 1311;
+    public final static short WIND_ARCHER_IV = 1312;
+
+    // Night Walker
+    public final static short NIGHT_WALKER_I = 1400;
+    public final static short NIGHT_WALKER_II = 1410;
+    public final static short NIGHT_WALKER_III = 1411;
+    public final static short NIGHT_WALKER_IV = 1412;
+
+    // Thunder Breaker
+    public final static short THUNDER_BREAKER_I = 1500;
+    public final static short THUNDER_BREAKER_II = 1510;
+    public final static short THUNDER_BREAKER_III = 1511;
+    public final static short THUNDER_BREAKER_IV = 1512;
+
+    // Aran
+    public final static short ARAN_I = 2100;
+    public final static short ARAN_II = 2110;
+    public final static short ARAN_III = 2111;
+    public final static short ARAN_IV = 2112;
+
+    // Evan
+    public final static short EVAN_I = 2200;
+    public final static short EVAN_II = 2210;
+    public final static short EVAN_III = 2211;
+    public final static short EVAN_IV = 2212;
+    public final static short EVAN_V = 2213;
+    public final static short EVAN_VI = 2214;
+    public final static short EVAN_VII = 2215;
+    public final static short EVAN_VIII = 2216;
+    public final static short EVAN_IX = 2217;
+    public final static short EVAN_X = 2218;
+
+    // Mercedes
+    public final static short MERCEDES_I = 2300;
+    public final static short MERCEDES_II = 2310;
+    public final static short MERCEDES_III = 2311;
+    public final static short MERCEDES_IV = 2312;
+
+    // Phantom
+    public final static short PHANTOM_I = 2400;
+    public final static short PHANTOM_II = 2410;
+    public final static short PHANTOM_III = 2411;
+    public final static short PHANTOM_IV = 2412;
+
+    // Luminous
+    public final static short LUMINOUS_I = 2700;
+    public final static short LUMINOUS_II = 2710;
+    public final static short LUMINOUS_III = 2711;
+    public final static short LUMINOUS_IV = 2712;
+
+    // ZERO
+    public final static short ZERO = 10000;
+
+    // Allows conversion from (Short) ID to (String) Job Name
+    // Contains all known classes including GMS exclusives (for posterity)
+    // @author KOOKIIE
+    // ported from: https://github.com/TEAM-SPIRIT-Productions/MapleStoryJobIDs
+    public static final Map<Short, String> JOB_NAME = new HashMap<Short, String>(){{
+        put(BEGINNER, "Beginner");
+
+        put(WARRIOR, "Warrior");
+        put(FIGHTER, "Fighter");
+        put(CRUSADER, "Crusader");
+        put(HERO, "Hero");
+        put(PAGE, "Page");
+        put(WHITE_KNIGHT, "White Knight'");
+        put(PALADIN, "Paladin");
+        put(SPEARMAN, "Spearman");
+        put(DRAGON_KNIGHT, "Dragon Knight'");
+        put(DARK_KNIGHT, "Dark Knight");
+
+        put(MAGICIAN, "Magician");
+        put(FIRE_POISON_I, "Fire/Poison Wizard");
+        put(FIRE_POISON_II, "Fire/Poison Mage");
+        put(FIRE_POISON_III, "Fire/Poison Archmage");
+        put(ICE_LIGHTNING_I, "Ice/Lightning Wizard");
+        put(ICE_LIGHTNING_II, "Ice/Lightning Mage");
+        put(ICE_LIGHTNING_III, "Ice/Lightning Archmage");
+        put(CLERIC, "Cleric");
+        put(PRIEST, "Priest");
+        put(BISHOP, "Bishop");
+
+        put(ARCHER, "Archer");
+        put(HUNTER, "Hunter");
+        put(RANGER, "Ranger");
+        put(BOWMASTER, "Bowmaster");
+        put((short) 320, "Cross Bowman");
+        put((short) 321, "Sniper");
+        put((short) 322, "Marksman");
+        put((short) 301, "Pathfinder");
+        put((short) 330, "Pathfinder");
+        put((short) 331, "Pathfinder");
+        put((short) 332, "Pathfinder");
+
+        put((short) 400, "Rogue");
+        put((short) 410, "Assassin");
+        put((short) 411, "Hermit");
+        put((short) 412, "Night Lord");
+        put((short) 420, "Bandit");
+        put((short) 421, "Chief Bandit");
+        put((short) 422, "Shadower");
+        put((short) 430, "Blade Recruit");
+        put((short) 431, "Blade Acolyte");
+        put((short) 432, "Blade Specialist");
+        put((short) 433, "Blade Lord");
+        put((short) 434, "Blade Master");
+
+        put((short) 500, "Pirate");
+        put((short) 510, "Brawler");
+        put((short) 511, "Marauder");
+        put((short) 512, "Buccaneer");
+        put((short) 520, "Gunslinger");
+        put((short) 521, "Outlaw");
+        put((short) 522, "Corsair");
+        put((short) 501, "Cannon Shooter");
+        put((short) 530, "Cannoneer");
+        put((short) 531, "Cannon Trooper");
+        put((short) 532, "Cannon Master");
+        put((short) 508, "Jett");
+        put((short) 570, "Jett");
+        put((short) 571, "Jett");
+        put((short) 572, "Jett");
+
+        put((short) 1000, "Noblesse");
+        put(DAWN_WARRIOR_I, "Dawn Warrior");
+        put(DAWN_WARRIOR_II, "Dawn Warrior");
+        put(DAWN_WARRIOR_III, "Dawn Warrior");
+        put(DAWN_WARRIOR_IV, "Dawn Warrior");
+        put(BLAZE_WIZARD_I, "Blaze Wizard");
+        put(BLAZE_WIZARD_II, "Blaze Wizard");
+        put(BLAZE_WIZARD_III, "Blaze Wizard");
+        put(BLAZE_WIZARD_IV, "Blaze Wizard");
+        put(WIND_ARCHER_I, "Wind Archer");
+        put(WIND_ARCHER_II, "Wind Archer");
+        put(WIND_ARCHER_III, "Wind Archer");
+        put(WIND_ARCHER_IV, "Wind Archer");
+        put(NIGHT_WALKER_I, "Night Walker");
+        put(NIGHT_WALKER_II, "Night Walker");
+        put(NIGHT_WALKER_III, "Night Walker");
+        put(NIGHT_WALKER_IV, "Night Walker");
+        put(THUNDER_BREAKER_I, "Thunder Breaker");
+        put(THUNDER_BREAKER_II, "Thunder Breaker");
+        put(THUNDER_BREAKER_III, "Thunder Breaker");
+        put(THUNDER_BREAKER_IV, "Thunder Breaker");
+
+        put((short) 2000, "Aran");
+        put(ARAN_I, "Aran");
+        put(ARAN_II, "Aran");
+        put(ARAN_III, "Aran");
+        put(ARAN_IV, "Aran");
+        put((short) 2001, "Evan");
+        put(EVAN_I, "Evan");
+        put(EVAN_II, "Evan");
+        put(EVAN_III, "Evan");
+        put(EVAN_IV, "Evan");
+        put(EVAN_V, "Evan");
+        put(EVAN_VI, "Evan");
+        put(EVAN_VII, "Evan");
+        put(EVAN_VIII, "Evan");
+        put(EVAN_IX, "Evan");
+        put(EVAN_X, "Evan");
+        put((short) 2002, "Mercedes");
+        put(MERCEDES_I, "Mercedes");
+        put(MERCEDES_II, "Mercedes");
+        put(MERCEDES_III, "Mercedes");
+        put(MERCEDES_IV, "Mercedes");
+        put((short) 2003, "Phantom");
+        put(PHANTOM_I, "Phantom");
+        put(PHANTOM_II, "Phantom");
+        put(PHANTOM_III, "Phantom");
+        put(PHANTOM_IV, "Phantom");
+        put((short) 2005, "Shade");
+        put((short) 2500, "Shade");
+        put((short) 2510, "Shade");
+        put((short) 2511, "Shade");
+        put((short) 2512, "Shade");
+        put((short) 2004, "Luminous");
+        put(LUMINOUS_I, "Luminous");
+        put(LUMINOUS_II, "Luminous");
+        put(LUMINOUS_III, "Luminous");
+        put(LUMINOUS_IV, "Luminous");
+
+        put((short) 3000, "Citizen");
+        put((short) 3001, "Demon");
+        put((short) 3100, "Demon Slayer");
+        put((short) 3110, "Demon Slayer");
+        put((short) 3111, "Demon Slayer");
+        put((short) 3112, "Demon Slayer");
+        put((short) 3101, "Demon Avenger");
+        put((short) 3120, "Demon Avenger");
+        put((short) 3121, "Demon Avenger");
+        put((short) 3122, "Demon Avenger");
+
+        put((short) 3200, "Battle Mage");
+        put((short) 3210, "Battle Mage");
+        put((short) 3211, "Battle Mage");
+        put((short) 3212, "Battle Mage");
+        put((short) 3300, "Wild Hunter");
+        put((short) 3310, "Wild Hunter");
+        put((short) 3311, "Wild Hunter");
+        put((short) 3312, "Wild Hunter");
+        put((short) 3500, "Mechanic");
+        put((short) 3510, "Mechanic");
+        put((short) 3511, "Mechanic");
+        put((short) 3512, "Mechanic");
+        put((short) 3002, "Xenon");
+        put((short) 3600, "Xenon");
+        put((short) 3610, "Xenon");
+        put((short) 3611, "Xenon");
+        put((short) 3612, "Xenon");
+        put((short) 3700, "Blaster");
+        put((short) 3710, "Blaster");
+        put((short) 3711, "Blaster");
+        put((short) 3712, "Blaster");
+
+        put((short) 4001, "Hayato");
+        put((short) 4100, "Hayato");
+        put((short) 4110, "Hayato");
+        put((short) 4111, "Hayato");
+        put((short) 4112, "Hayato");
+        put((short) 4002, "Kanna");
+        put((short) 4200, "Kanna");
+        put((short) 4210, "Kanna");
+        put((short) 4211, "Kanna");
+        put((short) 4212, "Kanna");
+
+        put((short) 5000, "Mihile");
+        put((short) 5100, "Mihile");
+        put((short) 5110, "Mihile");
+        put((short) 5111, "Mihile");
+        put((short) 5112, "Mihile");
+
+        put((short) 6000, "Kaiser");
+        put((short) 6100, "Kaiser");
+        put((short) 6110, "Kaiser");
+        put((short) 6111, "Kaiser");
+        put((short) 6112, "Kaiser");
+        put((short) 6001, "Angelic Buster");
+        put((short) 6500, "Angelic Buster");
+        put((short) 6510, "Angelic Buster");
+        put((short) 6511, "Angelic Buster");
+        put((short) 6512, "Angelic Buster");
+        put((short) 6002, "Cadena");
+        put((short) 6400, "Cadena");
+        put((short) 6410, "Cadena");
+        put((short) 6411, "Cadena");
+        put((short) 6412, "Cadena");
+        put((short) 6003, "Kain");
+        put((short) 6300, "Kain");
+        put((short) 6310, "Kain");
+        put((short) 6311, "Kain");
+        put((short) 6312, "Kain");
+
+        put(ZERO, "Zero");
+        put((short) 10100, "Zero");
+        put((short) 10110, "Zero");
+        put((short) 10111, "Zero");
+        put((short) 10112, "Zero");
+
+        put((short) 11000, "Beast Tamer");
+        put((short) 11200, "Beast Tamer");
+        put((short) 11210, "Beast Tamer");
+        put((short) 11211, "Beast Tamer");
+        put((short) 11212, "Beast Tamer");
+
+        put((short) 14000, "Kinesis");
+        put((short) 14200, "Kinesis");
+        put((short) 14210, "Kinesis");
+        put((short) 14211, "Kinesis");
+        put((short) 14212, "Kinesis");
+
+        put((short) 15000, "Illium");
+        put((short) 15200, "Illium");
+        put((short) 15210, "Illium");
+        put((short) 15211, "Illium");
+        put((short) 15212, "Illium");
+        put((short) 15001, "Ark");
+        put((short) 15500, "Ark");
+        put((short) 15510, "Ark");
+        put((short) 15511, "Ark");
+        put((short) 15512, "Ark");
+        put((short) 15002, "Adele");
+        put((short) 15100, "Adele");
+        put((short) 15110, "Adele");
+        put((short) 15112, "Adele");
+        put((short) 15111, "Adele");
+
+        put((short) 16000, "Hoyoung");
+        put((short) 16400, "Hoyoung");
+        put((short) 16410, "Hoyoung");
+        put((short) 16411, "Hoyoung");
+        put((short) 16412, "Hoyoung");
+
+        put((short) 800, "Manager");
+        put((short) 900, "GM");
+        put((short) 910, "Super GM");
+        put((short) 9000, "Additional Skills");
+        put((short) 40000, "V-Skills");
+
+        put((short) 13000, "Pink Bean");
+        put((short) 13100, "Pink Bean");
+    }};
+
+    // Job Advancement message prefix
+    public final static String advancePrefix = "You have made the job advancement to ";
+}

--- a/AzureMS/src/handlers/LoginHandler/AutoRegister.java
+++ b/AzureMS/src/handlers/LoginHandler/AutoRegister.java
@@ -1,11 +1,11 @@
-package handlers.LoginHandler;;
+package handlers.LoginHandler;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 import client.MapleClient;
-import com.sun.security.ntlm.Server;
+// import com.sun.security.ntlm.Server;
 import constants.ServerConstants;
 import connections.Database.MYSQL;
 import org.mindrot.jbcrypt.BCrypt;

--- a/AzureMS/src/server/LifeEntity/MobEntity/MonsterEntity/MapleMonster.java
+++ b/AzureMS/src/server/LifeEntity/MobEntity/MonsterEntity/MapleMonster.java
@@ -280,7 +280,7 @@ public class MapleMonster extends AbstractLoadedMapleLife {
         if (from.getMapId() == 120000102) {
             from.addDamageMeter(rDamage);
             from.send(MainPacketCreator.RemovePopupSay());
-            from.send(MainPacketCreator.OnAddPopupSay(9000036, 3000, "ëˆ„ì  ë°ë¯¸ì§€ #e[#n#r" + Randomizer.Comma(from.getDamageMeter()) + "#k#e]", ""));
+            from.send(MainPacketCreator.OnAddPopupSay(9000036, 3000, "´©Àû µ¥¹ÌÁö #e[#n#r" + Randomizer.Comma(from.getDamageMeter()) + "#k#e]", ""));
         }
 
         if (finalmaxhp > 0) {
@@ -500,9 +500,9 @@ public class MapleMonster extends AbstractLoadedMapleLife {
         long highdamage = 0;
 
         if (Randomizer.nextInt(100) <= 2) {
-            if (killer.getLevel() - getStats().getLevel() <= 5) { // ëª¬ìŠ¤í„°ë ˆë²¨ ë³´ë‹¤ 5ì´ìƒ ë†’ìœ¼ë©´ë“œë¡­ì•ˆë¨
+            if (killer.getLevel() - getStats().getLevel() <= 5) { // ¸ó½ºÅÍ·¹º§ º¸´Ù 5ÀÌ»ó ³ôÀ¸¸éµå·Ó¾ÈµÊ
                 cash = Randomizer.rand(50, 150);
-            } else if (killer.getLevel() - getStats().getLevel() <= -20) { // ëª¬ìŠ¤í„°ë ˆë²¨ ë³´ë‹¤ 20ì´ìƒ ë‚®ìœ¼ë©´ ë”ë†’ê²Œ
+            } else if (killer.getLevel() - getStats().getLevel() <= -20) { // ¸ó½ºÅÍ·¹º§ º¸´Ù 20ÀÌ»ó ³·À¸¸é ´õ³ô°Ô
                 cash = Randomizer.rand(60, 200);
             }
         }


### PR DESCRIPTION
- Fix existing bugs for Dual Blade, and reduce the number of cases in auto-job advancement
  - Add Hashmap that maps all  job IDs in MapleStory to their respective class names
- Clean-up Maven issues; importing Maven script is expected to set the project up perfectly now
  - Add encoding (`x-windows-949`) to Maven
  - Add source directory to Maven (should not need to manually set it now)
  - Comment out unused imports causing Maven compiles to fail (`com.sun.security.ntlm`)
  - Convert BOM of MapleMonster.java from `UTF-8` to `x-windows-949`
- Update `.gitignore`
  - Now ignoring chat logs (which should never have been committed in the first place)